### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,34 @@
-# Changelog
+## 0.3.0+1
 
-# 0.3.0
-- Fix #23
+* Fix changelog
 
-## 0.2.2 - 0.2.5
-- Bug fixes
-- Fix #14
+## 0.3.0
+
+* Fix #23
+
+## 0.2.5
+
+* Bug fixes
+* Fix #14
 
 ## 0.2.1
-- `ImplicitlyAnimatedList` now always uses the latest items, even if `listEquals()` is `true`.
 
-# 0.2.0
-- Added support for headers and footers on the `ImplicitlyAnimatedReorderableList`.
-- Added `child` property on `Reorderable` that can be used instead off the `builder` that will use a default elevation animation instead of being forced to specify your own custom animation.
+* `ImplicitlyAnimatedList` now always uses the latest items, even if `listEquals()` is `true`.
 
-## 0.1.5 to 0.1.10
-- Bug fixes and performance improvements.
+## 0.2.0
+
+* Added support for headers and footers on the `ImplicitlyAnimatedReorderableList`.
+* Added `child` property on `Reorderable` that can be used instead off the `builder` that will use a default elevation animation instead of being forced to specify your own custom animation.
+
+## 0.1.10
+
+* Bug fixes and performance improvements.
 
 ## 0.1.4
-- Made `Handle` scroll aware to only initiate a drag when the scroll position didn't change.
-- Added horizontal scrollDirection support for `ImplicitlyAnimatedReorderableList`
+
+* Made `Handle` scroll aware to only initiate a drag when the scroll position didn't change.
+* Added horizontal scrollDirection support for `ImplicitlyAnimatedReorderableList`
 
 ## 0.1.0
-- Initial release
+
+* Initial release

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: implicitly_animated_reorderable_list
 description: A Flutter ListView that implicitly animates between the changes of two lists with the support to reorder its items.
-version: 0.3.0
+version: 0.3.0+1
 homepage: https://github.com/BendixMa/implicitly_animated_reorderable_list/tree/master/example/lib/ui
 
 environment:
@@ -15,5 +15,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,3 +15,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+flutter:


### PR DESCRIPTION
## Introduction

First of all, thank you so much for creating this awesome package 🚀 🤘

## Description

If you take a look at the package changelog [on Pub](), you can see that is completely screwed up:

<a href="https://ibb.co/WxBBxB2"><img src="https://i.ibb.co/SsVVsV3/image.png" alt="image" border="0"></a>

In order to fix this, I took the [`package_info` package CHANGELOG](https://github.com/flutter/plugins/blob/0aecd1fd2b631a1f314f81d77c003c4d7f767c90/packages/package_info/CHANGELOG.md) (official package by the Flutter team) and applied the formatting to the changelog here.

## Changes

* The common practice (taking a look at all official Flutter packages and plugins) is starting with version entries → no title anymore.
* The character for bullet points that is usually used is `*`. This also better matches what they will look like on Pub and GitHub.
* **All version** use H2, i.e. `##` - this is **required** for proper formatting on Pub.
* There should be **one heading per version**, which can be used for hyperlinking, e.g. https://pub.dev/packages/implicitly_animated_reorderable_list/changelog#030. Therefore, I removed the "... to ..." headers, implying that the previous versions also worked towards the changes described. In the future, you will want to add a changelog entry for every version.