### PR TITLE
Fix #43. bug on different size items

### DIFF
--- a/example/lib/ui/lang_page.dart
+++ b/example/lib/ui/lang_page.dart
@@ -240,6 +240,8 @@ class _LanguagePageState extends State<LanguagePage> with SingleTickerProviderSt
         color: color,
         elevation: elevation,
         alignment: Alignment.center,
+        // For testing different size item. You can comment this line
+        padding: lang.englishName == 'English' ? const EdgeInsets.symmetric(vertical: 16.0) : EdgeInsets.zero,
         child: ListTile(
           title: Text(
             lang.nativeName,

--- a/lib/src/implicitly_animated_reorderable_list.dart
+++ b/lib/src/implicitly_animated_reorderable_list.dart
@@ -236,7 +236,7 @@ class ImplicitlyAnimatedReorderableListState<E>
   Key get dragKey => dragItem?.key;
   int get _dragIndex => dragItem?.index;
   double get _dragStart => dragItem.start + _dragDelta;
-  // double get _dragEnd => dragItem.end + _dragDelta;
+  double get _dragEnd => dragItem.end + _dragDelta;
   double get _dragCenter => dragItem.middle + _dragDelta;
   double get _dragSize => isVertical ? dragItem.height : dragItem.width;
 
@@ -338,18 +338,19 @@ class ImplicitlyAnimatedReorderableListState<E>
       final translation = getTranslation(key);
 
       final index = item.index;
-      final currentItemCenter = item.middle + translation;
+      final itemStart = item.start + translation;
+      final itemEnd = item.end + translation;
 
       if (index < _dragIndex) {
-        if (currentItemCenter >= _dragCenter && translation == 0) {
+        if (itemStart >= _dragStart && translation == 0) {
           _dispatchMove(key, _dragSize);
-        } else if (currentItemCenter <= _dragCenter && translation != 0) {
+        } else if (itemEnd <= _dragEnd && translation != 0) {
           _dispatchMove(key, 0);
         }
       } else if (index > _dragIndex) {
-        if (currentItemCenter >= _dragCenter && translation != 0) {
+        if (itemStart >= _dragStart && translation != 0) {
           _dispatchMove(key, 0);
-        } else if (currentItemCenter <= _dragCenter && translation == 0) {
+        } else if (itemEnd <= _dragEnd && translation == 0) {
           _dispatchMove(key, -_dragSize);
         }
       }


### PR DESCRIPTION
Hi, again.
I had fixed #23 but there is bug when items have different sizes.
![Screenshot_20201030-055238](https://user-images.githubusercontent.com/10491866/97631448-58023400-1a74-11eb-86a6-1d05ff7410f2.jpg)

'English' is bigger than 'German'.
In this situation, we cannot drag up 'English' because I compared itemCenter and dragCenter
It cannot be itemCenter(German's) >= dragCenter(English's) since ceil is blocked.

So, we should focus on top(start) and bottom(end)